### PR TITLE
Add RITA usage guide and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ the exercises. Access it from any machine in the training environment using:
 - **Username:**
 - **Password:**
 
-Refer to the [RITA guide](content/rita_guide.md) for detailed instructions. The
-exercises require using RITA to build asset inventories, model threats and
-document overall risk evaluations.
+Refer to the [RITA guide](content/rita_guide.md) for step-by-step instructions on logging in, creating assets, mapping threats and vulnerabilities, evaluating risk, and importing data. The exercises require using RITA to build asset inventories, model threats and document overall risk evaluations.
 
 ## Deployment
 

--- a/content/exercise1.md
+++ b/content/exercise1.md
@@ -22,7 +22,7 @@ You are the Cybersecurity Risk Manager for a major retail bank offering online s
 
 ## Steps
 1. Map critical assets and data flows between the provided machines.
-2. Log into RITA and model bank assets, threats, and countermeasures following the RITA guide.
+2. Log into RITA and model bank assets, threats, and countermeasures following the [RITA guide](rita_guide.md).
 3. Build threat scenarios using STRIDE and MITRE ATT&CK techniques.
 4. Assess the likelihood and impact of each scenario.
 5. Propose mitigations and prioritise them in a risk treatment plan.

--- a/content/exercise2.md
+++ b/content/exercise2.md
@@ -22,7 +22,7 @@ You are acting as the Cybersecurity Risk Manager for a national power transmissi
 
 ## Steps
 1. Identify ICS and IT assets critical to operations.
-2. Use RITA to model ICS assets, potential threats and vulnerabilities.
+2. Use RITA to model ICS assets, potential threats and vulnerabilities as described in the [RITA guide](rita_guide.md).
 3. Model threat scenarios such as malware propagation from IT to OT, insider manipulation of SCADA and unauthorised RTU commands.
 4. Assess safety, operational and strategic impact.
 5. Recommend controls suited for industrial environments.

--- a/content/rita_guide.md
+++ b/content/rita_guide.md
@@ -1,0 +1,30 @@
+# RITA Quick Guide
+
+This guide summarises the main steps for working with RITA (Risk Identification and Threat Assessment).
+
+## Login
+1. Navigate to `https://ng-soc.eurodyn.com/login`.
+2. Enter the username and password provided in the exercise.
+3. Click **Log In** to access the dashboard.
+   *Nota: en español, los campos se muestran como **Usuario** y **Contraseña**.*
+
+## Asset Creation
+1. From the dashboard, choose **Assets → Add Asset**.
+2. Provide name, description, and owner.
+3. Save the asset; repeat for each system component.
+   *Nota: utilice “Guardar” para confirmar el registro.*
+
+## Threat and Vulnerability Mapping
+1. Open an asset and use **Threats → Add Threat** to assign relevant threats.
+2. Link vulnerabilities via **Vulnerabilities → Add Vulnerability**.
+3. Capture references or evidence in the provided fields.
+
+## Risk Evaluation
+1. Within the asset, select **Risk Evaluation**.
+2. Estimate likelihood and impact; RITA calculates the risk score.
+3. Document existing controls and recommended treatments.
+
+## Imports
+1. Use **Data Import** in the main menu to upload CSV or JSON templates.
+2. Map incoming fields to RITA’s schema and run the import.
+3. Review imported records for accuracy.


### PR DESCRIPTION
## Summary
- Add concise RITA quick guide covering login, assets, threat/vulnerability mapping, risk evaluation, and imports
- Link the guide from the main README and both exercises for easy reference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e6d69dd0832da12f8b9069a1ea81