### PR TITLE
feat: add RITA server host and provisioning

### DIFF
--- a/sandboxes/provisioning_puc1/site.yml
+++ b/sandboxes/provisioning_puc1/site.yml
@@ -43,6 +43,21 @@
         regexp: '^bind-address'
         line: 'bind-address = 0.0.0.0'
 
+- name: Install and configure RITA
+  hosts: rita-server
+  become: true
+  tasks:
+    - name: Install RITA
+      ansible.builtin.apt:
+        update_cache: true
+        name: rita
+        state: present
+    - name: Ensure RITA service is running
+      ansible.builtin.service:
+        name: rita
+        state: started
+        enabled: true
+
 - name: Remove UFW from all hosts
   hosts: all
   become: true

--- a/sandboxes/provisioning_puc3/site.yml
+++ b/sandboxes/provisioning_puc3/site.yml
@@ -29,6 +29,21 @@
       ansible.builtin.shell: nohup nc -lkp 102 >/dev/null 2>&1 &
       changed_when: false
 
+- name: Install and configure RITA
+  hosts: rita-server
+  become: true
+  tasks:
+    - name: Install RITA
+      ansible.builtin.apt:
+        update_cache: true
+        name: rita
+        state: present
+    - name: Ensure RITA service is running
+      ansible.builtin.service:
+        name: rita
+        state: started
+        enabled: true
+
 - name: Remove UFW from all hosts
   hosts: all
   become: true

--- a/sandboxes/topology_puc1.yaml
+++ b/sandboxes/topology_puc1.yaml
@@ -1,4 +1,5 @@
 name: ngsoc-lm2-puc1
+# RITA reachable at rita-server (10.0.1.40)
 hosts:
   - name: bank-analyst
     base_box:
@@ -11,6 +12,11 @@ hosts:
       mgmt_user: debian
     flavor: csirtmu.tiny1x2
   - name: bank-db
+    base_box:
+      image: debian-11
+      mgmt_user: debian
+    flavor: csirtmu.tiny1x2
+  - name: rita-server
     base_box:
       image: debian-11
       mgmt_user: debian
@@ -37,6 +43,9 @@ net_mappings:
   - host: bank-db
     network: bank-net
     ip: 10.0.1.30
+  - host: rita-server
+    network: bank-net
+    ip: 10.0.1.40
 router_mappings:
   - router: router
     network: bank-net

--- a/sandboxes/topology_puc3.yaml
+++ b/sandboxes/topology_puc3.yaml
@@ -1,4 +1,5 @@
 name: ngsoc-lm2-puc3
+# RITA reachable at rita-server (10.0.2.40)
 hosts:
   - name: corp-workstation
     base_box:
@@ -11,6 +12,11 @@ hosts:
       mgmt_user: debian
     flavor: csirtmu.tiny1x2
   - name: substation-rtu
+    base_box:
+      image: debian-11
+      mgmt_user: debian
+    flavor: csirtmu.tiny1x2
+  - name: rita-server
     base_box:
       image: debian-11
       mgmt_user: debian
@@ -37,6 +43,9 @@ net_mappings:
   - host: substation-rtu
     network: ics-net
     ip: 10.0.2.30
+  - host: rita-server
+    network: ics-net
+    ip: 10.0.2.40
 router_mappings:
   - router: router
     network: ics-net

--- a/topology.yml
+++ b/topology.yml
@@ -1,4 +1,5 @@
 name: ngsoc-lm2
+# RITA reachable at rita-server (10.0.1.40)
 hosts:
   - name: bank-analyst
     base_box:
@@ -30,6 +31,11 @@ hosts:
       image: debian-12-x86_64
       mgmt_user: debian
     flavor: standard.medium
+  - name: rita-server
+    base_box:
+      image: debian-12-x86_64
+      mgmt_user: debian
+    flavor: standard.small
 routers:
   - name: router
     base_box:
@@ -63,6 +69,9 @@ net_mappings:
   - host: substation-rtu
     network: ics-net
     ip: 10.0.2.30
+  - host: rita-server
+    network: bank-net
+    ip: 10.0.1.40
 router_mappings:
   - router: router
     network: bank-net


### PR DESCRIPTION
## Summary
- document and expose a dedicated rita-server in all topology definitions
- provision RITA on the new host for PUC1 and PUC3 environments

## Testing
- `ansible-playbook --syntax-check sandboxes/provisioning_puc1/site.yml`
- `ansible-playbook --syntax-check sandboxes/provisioning_puc3/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7e78102a8832d8ba8d8bd83a71c8b