### PR TITLE
Secure debian user provisioning and sudo policy

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -66,6 +66,8 @@
 - name: Remove UFW from all hosts
   hosts: all
   become: true
+  vars_files:
+    - vars/users.yml
   tasks:
     - name: Remove UFW firewall
       ansible.builtin.apt:
@@ -74,11 +76,12 @@
     - name: Create User
       ansible.builtin.user:
         name: debian
-        password: "{{ 'qwerty!23' | password_hash('sha512') }}"
+        password: "{{ debian_user_password_hash }}"
+        update_password: on_create
         state: present
     - name: Give sudo privileges
       ansible.builtin.copy:
         dest: /etc/sudoers.d/debian
-        content: "debian ALL=(ALL) NOPASSWD:ALL"
+        content: "debian ALL=(ALL) /usr/bin/apt-get, /usr/bin/systemctl"
         mode: '0440'
         validate: 'visudo -cf %s'

--- a/provisioning/vars/users.yml
+++ b/provisioning/vars/users.yml
@@ -1,0 +1,4 @@
+# Variables for user accounts.
+# Supply a hashed password for 'debian_user_password_hash' using a secure
+# mechanism such as environment variables or Ansible Vault.
+debian_user_password_hash: "{{ lookup('env', 'DEBIAN_PASSWORD_HASH') }}"


### PR DESCRIPTION
## Summary
- reference hashed password via variable and vars file
- restrict debian's sudo access to limited commands requiring authentication

## Testing
- `ansible-playbook provisioning/playbook.yml --syntax-check`
- `ansible-lint provisioning/playbook.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7e9a3afb4832d9fa4a78c0317e84c