### PR TITLE
Replace nc shell listeners with systemd services

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -56,12 +56,24 @@
         update_cache: true
         name: netcat-openbsd
         state: present
-    - name: Open Modbus port (502)
-      ansible.builtin.shell: nohup nc -lkp 502 >/dev/null 2>&1 &
-      changed_when: false
-    - name: Open S7comm port (102)
-      ansible.builtin.shell: nohup nc -lkp 102 >/dev/null 2>&1 &
-      changed_when: false
+    - name: Deploy netcat listener service
+      ansible.builtin.template:
+        src: templates/nc-listener@.service.j2
+        dest: /etc/systemd/system/nc-listener@.service
+        mode: '0644'
+    - name: Reload systemd to pick up nc listener unit
+      ansible.builtin.systemd:
+        daemon_reload: true
+    - name: Ensure Modbus service listening on port 502
+      ansible.builtin.service:
+        name: nc-listener@502
+        state: started
+        enabled: true
+    - name: Ensure S7comm service listening on port 102
+      ansible.builtin.service:
+        name: nc-listener@102
+        state: started
+        enabled: true
 
 - name: Remove UFW from all hosts
   hosts: all

--- a/provisioning/templates/nc-listener@.service.j2
+++ b/provisioning/templates/nc-listener@.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Netcat listener on port %i
+After=network.target
+
+[Service]
+ExecStart=/bin/nc -lkp %i
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/sandboxes/provisioning_puc3/site.yml
+++ b/sandboxes/provisioning_puc3/site.yml
@@ -22,12 +22,24 @@
         update_cache: true
         name: netcat
         state: present
-    - name: Open Modbus port (502)
-      ansible.builtin.shell: nohup nc -lkp 502 >/dev/null 2>&1 &
-      changed_when: false
-    - name: Open S7comm port (102)
-      ansible.builtin.shell: nohup nc -lkp 102 >/dev/null 2>&1 &
-      changed_when: false
+    - name: Deploy netcat listener service
+      ansible.builtin.template:
+        src: templates/nc-listener@.service.j2
+        dest: /etc/systemd/system/nc-listener@.service
+        mode: '0644'
+    - name: Reload systemd to pick up nc listener unit
+      ansible.builtin.systemd:
+        daemon_reload: true
+    - name: Ensure Modbus service listening on port 502
+      ansible.builtin.service:
+        name: nc-listener@502
+        state: started
+        enabled: true
+    - name: Ensure S7comm service listening on port 102
+      ansible.builtin.service:
+        name: nc-listener@102
+        state: started
+        enabled: true
 
 - name: Install and configure RITA
   hosts: rita-server

--- a/sandboxes/provisioning_puc3/templates/nc-listener@.service.j2
+++ b/sandboxes/provisioning_puc3/templates/nc-listener@.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Netcat listener on port %i
+After=network.target
+
+[Service]
+ExecStart=/bin/nc -lkp %i
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- manage netcat listeners via systemd instead of shell
- add template unit and enable ports 502 and 102 with Ansible service module

## Testing
- `ansible-playbook --syntax-check provisioning/playbook.yml`
- `ansible-playbook --syntax-check sandboxes/provisioning_puc3/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7eae51a68832d94ff2e6218367d69