### PR TITLE
Use idempotent iptables modules for router NAT configuration

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -8,14 +8,32 @@
         name: net.ipv4.ip_forward
         value: '1'
         state: present
-    - name: Set up NAT for bank-net
-      ansible.builtin.command: >
-        iptables -t nat -A POSTROUTING -s 10.0.1.0/24 -o eth2 -j MASQUERADE
-      changed_when: false
-    - name: Set up NAT for ics-net
-      ansible.builtin.command: >
-        iptables -t nat -A POSTROUTING -s 10.0.2.0/24 -o eth2 -j MASQUERADE
-      changed_when: false
+    - name: Ensure iptables-persistent is installed
+      ansible.builtin.apt:
+        name: iptables-persistent
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+    - name: Ensure NAT for bank-net is configured
+      ansible.posix.iptables:
+        table: nat
+        chain: POSTROUTING
+        source: 10.0.1.0/24
+        out_interface: eth2
+        jump: MASQUERADE
+        state: present
+    - name: Ensure NAT for ics-net is configured
+      ansible.posix.iptables:
+        table: nat
+        chain: POSTROUTING
+        source: 10.0.2.0/24
+        out_interface: eth2
+        jump: MASQUERADE
+        state: present
+    - name: Persist iptables rules
+      community.general.iptables_state:
+        state: saved
+        path: /etc/iptables/rules.v4
 
 - name: Configure bank web server
   hosts: bank-web

--- a/sandboxes/provisioning_puc1/site.yml
+++ b/sandboxes/provisioning_puc1/site.yml
@@ -8,10 +8,24 @@
         name: net.ipv4.ip_forward
         value: '1'
         state: present
-    - name: Set up NAT for bank-net
-      ansible.builtin.command: >
-        iptables -t nat -A POSTROUTING -s 10.0.1.0/24 -o eth2 -j MASQUERADE
-      changed_when: false
+    - name: Ensure iptables-persistent is installed
+      ansible.builtin.apt:
+        name: iptables-persistent
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+    - name: Ensure NAT for bank-net is configured
+      ansible.posix.iptables:
+        table: nat
+        chain: POSTROUTING
+        source: 10.0.1.0/24
+        out_interface: eth2
+        jump: MASQUERADE
+        state: present
+    - name: Persist iptables rules
+      community.general.iptables_state:
+        state: saved
+        path: /etc/iptables/rules.v4
 
 - name: Configure bank web server
   hosts: bank-web

--- a/sandboxes/provisioning_puc3/site.yml
+++ b/sandboxes/provisioning_puc3/site.yml
@@ -8,10 +8,24 @@
         name: net.ipv4.ip_forward
         value: '1'
         state: present
-    - name: Set up NAT for ics-net
-      ansible.builtin.command: >
-        iptables -t nat -A POSTROUTING -s 10.0.2.0/24 -o eth2 -j MASQUERADE
-      changed_when: false
+    - name: Ensure iptables-persistent is installed
+      ansible.builtin.apt:
+        name: iptables-persistent
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+    - name: Ensure NAT for ics-net is configured
+      ansible.posix.iptables:
+        table: nat
+        chain: POSTROUTING
+        source: 10.0.2.0/24
+        out_interface: eth2
+        jump: MASQUERADE
+        state: present
+    - name: Persist iptables rules
+      community.general.iptables_state:
+        state: saved
+        path: /etc/iptables/rules.v4
 
 - name: Configure substation RTU
   hosts: substation-rtu


### PR DESCRIPTION
## Summary
- replace the router NAT command tasks with ansible.posix.iptables so each MASQUERADE rule is applied exactly once in every scenario
- install iptables-persistent and save the active rules so the NAT configuration is kept across reboots

## Testing
- not run (ansible not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df7a860694832d9d401c6fcd4c04da