### PR TITLE
Fix netcat listener template path in PUC3 sandbox

### DIFF
--- a/sandboxes/provisioning_puc3/site.yml
+++ b/sandboxes/provisioning_puc3/site.yml
@@ -38,7 +38,7 @@
         state: present
     - name: Deploy netcat listener service
       ansible.builtin.template:
-        src: templates/nc-listener@.service.j2
+        src: ../../provisioning/templates/nc-listener@.service.j2
         dest: /etc/systemd/system/nc-listener@.service
         mode: '0644'
     - name: Reload systemd to pick up nc listener unit


### PR DESCRIPTION
## Summary
- update the PUC3 sandbox playbook to reference the shared nc listener template from the provisioning directory

## Testing
- `ansible-playbook sandboxes/provisioning_puc3/site.yml --syntax-check` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ba5ca7d4832d813e3744e8544f30