### PR TITLE
Use netcat-openbsd for ICS listener services

### DIFF
--- a/provisioning/templates/nc-listener@.service.j2
+++ b/provisioning/templates/nc-listener@.service.j2
@@ -3,7 +3,7 @@ Description=Netcat listener on port %i
 After=network.target
 
 [Service]
-ExecStart=/bin/nc -lkp %i
+ExecStart=/bin/nc.openbsd -lkp %i
 Restart=always
 
 [Install]

--- a/sandboxes/provisioning_puc3/site.yml
+++ b/sandboxes/provisioning_puc3/site.yml
@@ -34,7 +34,7 @@
     - name: Install netcat for ICS port simulation
       ansible.builtin.apt:
         update_cache: true
-        name: netcat
+        name: netcat-openbsd
         state: present
     - name: Deploy netcat listener service
       ansible.builtin.template:


### PR DESCRIPTION
## Summary
- install the netcat-openbsd package for the ICS listener sandbox playbook
- point the nc-listener systemd template at the netcat-openbsd binary

## Testing
- not run (ansible-playbook not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e65d6bcee0832dbf781c4e11ae4654